### PR TITLE
call cleanup on start

### DIFF
--- a/netlink.py
+++ b/netlink.py
@@ -203,6 +203,9 @@ if __name__ == '__main__':
         check_iface_type(args.vxlan[i], 'vxlan')
 
         managers.append(ConfigManager(args.wireguard[i], args.vxlan[i]))
+    
+    for manager in managers:
+        manager.cleanup()
 
     should_stop = False
 


### PR DESCRIPTION
In #95 we thought about cleaning up interfaces and routes on them, before the script starts, in order to make it more robust.
@lemoer I have not tested this; it's just so we do not forget to add this at all.

The cleanup does not appear to destroy anything in the ConfigManager instances, iirc.
As soon as one of use tested this and checked whether it even works as intended, we could merge this.