### PR TITLE
correctly import NetlinkError from pyroute2

### DIFF
--- a/netlink.py
+++ b/netlink.py
@@ -145,7 +145,7 @@ class ConfigManager:
                         dst=re.sub(r"/\d+$", "", peer.lladdr),
                     )
                 except NetlinkError as e:
-                    print_err("Inserting FDB entry failed for {peer.public_key} on {self.vx_interface}.")
+                    print_err(f"Inserting FDB entry failed for {peer.public_key} on {self.vx_interface}.")
                     print_err(str(e))
 
             with IPRoute() as ip:
@@ -157,7 +157,7 @@ class ConfigManager:
                         proto=RT_PROTO_ID,
                     )
                 except NetlinkError as e:
-                    print_err("Inserting FDB entry failed for {peer.public_key} on {self.vx_interface}.")
+                    print_err(f"Inserting FDB entry failed for {peer.public_key} on {self.vx_interface}.")
                     print_err(str(e))
 
             if new_state:

--- a/netlink.py
+++ b/netlink.py
@@ -11,6 +11,7 @@ from threading import Event
 import signal
 
 from pyroute2 import IPRoute
+from pyroute2.netlink.exceptions import NetlinkError
 import argparse
 import signal
 import os
@@ -143,7 +144,7 @@ class ConfigManager:
                         lladdr="00:00:00:00:00:00",
                         dst=re.sub(r"/\d+$", "", peer.lladdr),
                     )
-                except pyroute2.netlink.exceptions.NetlinkError as e:
+                except NetlinkError as e:
                     print_err("Inserting FDB entry failed for {peer.public_key} on {self.vx_interface}.")
                     print_err(str(e))
 
@@ -155,7 +156,7 @@ class ConfigManager:
                         oif=ip.link_lookup(ifname=self.wg_interface)[0],
                         proto=RT_PROTO_ID,
                     )
-                except pyroute2.netlink.exceptions.NetlinkError as e:
+                except NetlinkError as e:
                     print_err("Inserting FDB entry failed for {peer.public_key} on {self.vx_interface}.")
                     print_err(str(e))
 


### PR DESCRIPTION
I got the following error - importing the exception properly did help

```
pyroute2.netlink.exceptions.NetlinkError: (17, 'File exists')
During handling of the above exception, another exception occurred:
Traceback (most recent call last):
  File "/srv/wireguard/vxlan-glue/netlink.py", line 264, in <module>
    manager.push_vxlan_configs()
  File "/srv/wireguard/vxlan-glue/netlink.py", line 158, in push_vxlan_configs
    except pyroute2.netlink.exceptions.NetlinkError as e:
           ^^^^^^^^
NameError: name 'pyroute2' is not defined
```